### PR TITLE
Replace only the first hyphen

### DIFF
--- a/src/main/java/view/FeedbackBox.java
+++ b/src/main/java/view/FeedbackBox.java
@@ -157,7 +157,7 @@ public class FeedbackBox extends JPanel {
         this.currentBoxContents = this.currentBoxContents.stream()
                 .map(String::trim)
                 .filter(line -> line.startsWith(this.controller.getLineMarker()))
-                .map(line -> line.replace(this.controller.getLineMarker(), ""))
+                .map(line -> line.replaceFirst(this.controller.getLineMarker(), ""))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Should prevent hyphens from being removed from the middle of comments when they are added to the sidebar. Focus on issue https://github.com/mtorpey/FeedbackHelper/issues/4.